### PR TITLE
feat(a11y): add basic accessibility when the talk detail is opened

### DIFF
--- a/lib/AgendaView.js
+++ b/lib/AgendaView.js
@@ -1,6 +1,6 @@
 import { AgendaDayTemplate } from './AgendaDayTemplate';
 import { AgendaDayTableModel } from './AgendaDayTableModel';
-import { closest, debug } from './util';
+import { closest, debug, setTabIndex } from './util';
 import { TalkDetailsPopup } from './TalkDetailsPopup';
 
 /**
@@ -188,9 +188,11 @@ class AgendaView {
   }
 
   unselectTalk() {
+    const oldFocus = document.querySelector(`.ka-talk-title[data-hash="${this.selectedTalkHash}"]`);
     this.selectedTalkHash = undefined;
     this.selectedTalkCoords = undefined;
     const $selected = document.querySelector('.ka-table-td.selected');
+    const mainDocument = document.querySelector('body');
     $selected && $selected.classList.remove('selected');
     const $details = document.querySelector('.ka-talk-details-window');
     if ($details) {
@@ -198,6 +200,9 @@ class AgendaView {
       this.pushState(this.models[this.selectedDayId].name, this.selectedDayId);
     }
     document.querySelector('.ka-overlay').classList.add('ka-hidden');
+    mainDocument.setAttribute('aria-hidden', false);
+    setTabIndex(mainDocument, 0);
+    oldFocus.focus();
   }
 
   scrollToTalk(talk) {
@@ -236,7 +241,7 @@ class AgendaView {
     if (this.selectedTalkHash && !event.altKey && !event.ctrlKey && !event.shiftKey) {
       const keyCode = event.keyCode;
       if (keyCode == 27) {
-        this.modal.close();
+        this.unselectTalk();
       }
 
       const rowDelta =

--- a/lib/TalkDetailsPopup.js
+++ b/lib/TalkDetailsPopup.js
@@ -1,5 +1,5 @@
 import { formatMarkdown } from './stringutils';
-import { strToEl } from './util';
+import { strToEl, setTabIndex } from './util';
 import { TalkFeedback } from './feedback';
 
 class TalkDetailsPopup {
@@ -11,19 +11,18 @@ class TalkDetailsPopup {
   }
 
   render() {
-
     const talk = this.talk;
     let links = !talk.videoUrl && !talk.slidesUrl? '' : `<div class="ka-links ka-right">
       ${!talk.slidesUrl? '' : `<a href="${talk.slidesUrl}" target="_blank" class="icon-slideshare" title="Slides"><span class="sr-only">Slides in new window of "${talk.title}"</span></a>`}
       ${!talk.videoUrl? '' : `<a href="${talk.videoUrl}" target="_blank" class="icon-youtube-play" title="Video"><span class="sr-only">Video in new window of "${talk.title}"</span></a>`}
     </div>`;
     const html = `
-      <div class="ka-talk-details-window">
-        <a class="ka-close" title="close"></a>
+      <div class="ka-talk-details-window" role="dialog" aria-labelledby="title-dlg">
+        <a class="ka-close" title="close"><span class="sr-only">close the detail of the talk</span></a>
         <div class="ka-talk-details-viewport">
           <div class="ka-talk-details-inner">
             <div class="ka-talk-details-contents">
-              <h2 class="ka-talk-details-title">${links} ${talk.title} ${this.feedback.renderFeedback()}</h2>
+              <h2 id="title-dlg" class="ka-talk-details-title">${links} ${talk.title} ${this.feedback.renderFeedback()}</h2>
               <div class="ka-talk-details-description">${formatMarkdown(talk.description)}</div>
               ${this.renderTags(talk.tags)}
               <div class="ka-feedback-entries"></div>
@@ -35,8 +34,16 @@ class TalkDetailsPopup {
         </div>
       </div>
     `;
+    const mainDocument = document.querySelector('body');
+    mainDocument.setAttribute('aria-hidden', true);
+    setTabIndex(mainDocument, -1);
     document.body.insertAdjacentHTML('beforeend', html);
+    const lightbox = document.querySelector('.ka-talk-details-window');
+    const oldTabIndex = lightbox.getAttribute('tabindex');
     document.querySelector('.ka-overlay').classList.remove('ka-hidden');
+    lightbox.setAttribute('tabindex', 0);
+    lightbox.focus();
+    lightbox.setAttribute('tabindex', oldTabIndex);
     this.feedback.renderFeedbackEntries(document.querySelector('.ka-feedback-entries'));
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,6 +64,14 @@ export default {
     values = values.map(exports.escapeHtml);
     return strings.reduce((str, val, i) => str += val + (values[i] || ''), '');
   },
+  
+  setTabIndex(obj, tabIdx) {
+    const focusables = obj.querySelectorAll('a, button');
+    const len = focusables.length;
+    for(var i = 0; i < len; i++) {
+      focusables[i].setAttribute('tabindex', tabIdx);
+    }
+  },
 
   closest: function(el, selector) {
     if (el.closest) {


### PR DESCRIPTION
Added basic accessibility when the user opens a talk:
- set the focus into the lightbox
- disable all links and buttons under the lightbox
- return the focus to the talk in the table when the user closes the lightbox
- fix the keyup event when the user uses the "Escape" key.
- add text to the close link in the lightbox

Regards.
